### PR TITLE
[#19] 사용자 강화 상태 응답 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    // https://mvnrepository.com/artifact/org.projectlombok/lombok
+    implementation 'org.projectlombok:lombok:1.18.24'
+    annotationProcessor 'org.projectlombok:lombok:1.18.24'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/ohgiraffers/webrpg/user/application/dto/DTO.java
+++ b/src/main/java/com/ohgiraffers/webrpg/user/application/dto/DTO.java
@@ -1,4 +1,0 @@
-package com.ohgiraffers.webrpg.user.application.dto;
-
-public class DTO {
-}

--- a/src/main/java/com/ohgiraffers/webrpg/user/application/dto/UserInfoDTO.java
+++ b/src/main/java/com/ohgiraffers/webrpg/user/application/dto/UserInfoDTO.java
@@ -1,0 +1,22 @@
+package com.ohgiraffers.webrpg.user.application.dto;
+
+
+import com.ohgiraffers.webrpg.user.domain.aggregate.enumtype.ElementalType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserInfoDTO {
+
+    private String name;
+    private int totalHP;
+    private int totalSTR;
+    private int userLevel;
+    private int upgradeLevel;
+    private ElementalType elementalType;
+}

--- a/src/main/java/com/ohgiraffers/webrpg/user/application/dto/UserUpgradeStatDTO.java
+++ b/src/main/java/com/ohgiraffers/webrpg/user/application/dto/UserUpgradeStatDTO.java
@@ -1,0 +1,16 @@
+package com.ohgiraffers.webrpg.user.application.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserUpgradeStatDTO {
+    private int upgradeLevel;
+    private int totalHP;
+    private int totalSTR;
+}

--- a/src/main/java/com/ohgiraffers/webrpg/user/application/service/UserApplicationService.java
+++ b/src/main/java/com/ohgiraffers/webrpg/user/application/service/UserApplicationService.java
@@ -1,10 +1,15 @@
 package com.ohgiraffers.webrpg.user.application.service;
 
+import com.ohgiraffers.webrpg.user.application.dto.UserInfoDTO;
+import com.ohgiraffers.webrpg.user.application.dto.UserUpgradeStatDTO;
 import com.ohgiraffers.webrpg.user.domain.aggregate.entity.User;
 import com.ohgiraffers.webrpg.user.domain.repository.UserRepository;
 import com.ohgiraffers.webrpg.user.domain.service.UserDomainService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @Service
 public class UserApplicationService {
@@ -29,5 +34,44 @@ public class UserApplicationService {
 
     public User getUserBySequence(int sequence) {
         return userRepository.findUserBySequence(sequence);
+    }
+
+
+    // TODO 강사님께 질문 : Map<String,Integer> VS DTO
+    private Map<String,Integer> getStat(int userDefaultSTR, int userDefaultHp , int userLevel, int userUpgradeLevel) {
+        Map<String,Integer> result = new HashMap<>();
+        int userTotalSTR = userDomainService.calcTotalStrikingPower(userDefaultSTR, userLevel, userLevel);
+        int userTotalHP = userDomainService.calcTotalHP(userDefaultHp, userLevel, userUpgradeLevel);
+        result.put("totalSTR", userTotalSTR);
+        result.put("totalHP", userTotalHP);
+        return result;
+    }
+
+    public UserInfoDTO getInfo(User user) {
+        Map<String,Integer> userStat = getStat(user.getDefaultSTR(), user.getDefaultHP() ,user.getLevel(), user.getUpgradeLevel());
+        return new UserInfoDTO(
+                user.getName(),
+                userStat.get("totalSTR"),
+                userStat.get("totalHP"),
+                user.getLevel(),
+                user.getUpgradeLevel(),
+                user.getElementalType()
+        );
+    }
+
+    public UserUpgradeStatDTO getUpgradeStatByFlag(User user, String flag) {
+        int branch;
+        switch (flag) {
+            case "success" : branch = 1; break;
+            case "fail" : branch = -1; break;
+            default:
+                branch = 0; break;
+        }
+        Map<String,Integer> userStat = getStat(user.getDefaultSTR(), user.getDefaultHP() ,user.getLevel(), user.getUpgradeLevel() + branch);
+        return new UserUpgradeStatDTO(
+                user.getUpgradeLevel(),
+                userStat.get("totalSTR"),
+                userStat.get("totalHP")
+        );
     }
 }

--- a/src/main/java/com/ohgiraffers/webrpg/user/domain/aggregate/entity/User.java
+++ b/src/main/java/com/ohgiraffers/webrpg/user/domain/aggregate/entity/User.java
@@ -5,8 +5,9 @@ import com.ohgiraffers.webrpg.user.domain.aggregate.vo.Money;
 
 public class User {
 
-    private int sequence;
-    private String name;
+    // TODO VO를 통한 level값에 따른 유저 HP, STR, defensivePower 값 처리 [#20]
+    private final int sequence;
+    private final String name;
     private int defaultHP;
     private int defaultSTR;
     private Money money;

--- a/src/main/java/com/ohgiraffers/webrpg/user/domain/service/UserDomainService.java
+++ b/src/main/java/com/ohgiraffers/webrpg/user/domain/service/UserDomainService.java
@@ -1,7 +1,38 @@
 package com.ohgiraffers.webrpg.user.domain.service;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
 public class UserDomainService {
+
+    @Value("${strikingPowerConstantNumber:10}")
+    private int strikingPowerConstantNumber;
+
+    @Value("${HPConstantNumber:10}")
+    private int HPConstantNumber;
+
+    /**
+    # 사용자의 총 공격력 계산 메소드
+     기본 공격력 = 사용자의 defaultSTR + level * strikingPowerConstantNumber;
+     (strikingPowerConstantNumber 는 사전에 정의한 상수)
+     총 공격력 : 기본 공격력 * upgradeLevel 의 제곱
+     만약 upgradeLevel 이 0일 경우, 기본 공격력이 총 공격력
+     */
+    public int calcTotalStrikingPower(int defaultSTR ,int level, int upgradeLevel) {
+        int basicStrikingPower = defaultSTR + level * strikingPowerConstantNumber;
+        return upgradeLevel == 0 ? basicStrikingPower : basicStrikingPower * (int) Math.pow(upgradeLevel,2);
+    }
+
+    /**
+     # 사용자의 총 체력 계산 메소드
+     기본 체력 = 사용자의 defaultSTR + level * HPConstantNumber;
+     (HPConstantNumber 는 사전에 정의한 상수)
+     총 체력 : 기본 체력 * upgradeLevel 의 체력
+     만약 upgradeLevel 이 0일 경우, 기본 체력이 총 체력
+     */
+    public int calcTotalHP(int defaultHP ,int level, int upgradeLevel) {
+        int basicHP = defaultHP + level * HPConstantNumber;
+        return upgradeLevel == 0 ? basicHP : basicHP * (int) Math.pow(upgradeLevel,2);
+    }
 }

--- a/src/main/java/com/ohgiraffers/webrpg/user/domain/service/pay/Pay.java
+++ b/src/main/java/com/ohgiraffers/webrpg/user/domain/service/pay/Pay.java
@@ -1,4 +1,0 @@
-package com.ohgiraffers.webrpg.user.domain.service.pay;
-
-public class Pay {
-}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
-
+strikingPowerConstantNumber = 10
+HPConstantNumber = 10

--- a/src/test/java/com/ohgiraffers/webrpg/user/application/service/UserApplicationServiceTests.java
+++ b/src/test/java/com/ohgiraffers/webrpg/user/application/service/UserApplicationServiceTests.java
@@ -1,0 +1,7 @@
+package com.ohgiraffers.webrpg.user.application.service;
+
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class UserApplicationServiceTests {
+}

--- a/src/test/java/com/ohgiraffers/webrpg/user/domain/service/UserDomainServiceTests.java
+++ b/src/test/java/com/ohgiraffers/webrpg/user/domain/service/UserDomainServiceTests.java
@@ -1,0 +1,7 @@
+package com.ohgiraffers.webrpg.user.domain.service;
+
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class UserDomainServiceTests {
+}


### PR DESCRIPTION
# 무슨 이유로 코드를 변경했는지

---
* #19 
---
# 어떤 위험이나 장애가 발견되었는지

---
* 없음
---

# 어떤 부분에 리뷰어가 집중하면 좋을지

---
* `UserDomainService` 에서 사용자의 총 공격력과 총 체력 계산 메소드 구현
* `UserInfoDTO`와 `UserUpgradeStatDTO` 를 통해 컨트롤러별 응답 데이터 형태 분리
* `UserApplicationService` 에서 사용자의 종합 정보 응답 메소드 구현
* `UserApplicationService` 에서 강화 분기별 사용자 스탯 변경 값 응답 메소드 구현
---

# 관련 스크린샷

---
* 없음
---

# 테스트 계획 또는 완료 사항

---
* 추후 통합 테스트에서 테스트할 예정
