### PR TITLE
[#15, #21, #24] 사용자 레벨업 구현

### DIFF
--- a/src/main/java/com/ohgiraffers/webrpg/database/UserInMemoryDatabase.java
+++ b/src/main/java/com/ohgiraffers/webrpg/database/UserInMemoryDatabase.java
@@ -7,15 +7,17 @@ import com.ohgiraffers.webrpg.user.domain.aggregate.enumtype.ElementalType;
 import java.util.HashMap;
 import java.util.Map;
 
-public class UserInMemoryDatabase {
+public abstract class UserInMemoryDatabase {
 
     private static final Map<Integer, User> userMap = new HashMap<>();;
-
-    public UserInMemoryDatabase() {
+    static {
         userMap.put(1,new User(1, "소드마스터",
                 1000, 100,
-                new Money(10000), 100000,
+                new Money(0), 1,0,1,
                 ElementalType.FIRE));
+
+    }
+    private UserInMemoryDatabase() {
     }
 
     public static <T> T findUserBySequence(int sequence) {
@@ -27,5 +29,17 @@ public class UserInMemoryDatabase {
                 .filter(user ->user.getName().equals(name))
                 .findFirst()
                 .orElseThrow(IllegalArgumentException::new);
+    }
+
+    public static void saveLevel(int sequence, int level) {
+        userMap.get(sequence).setLevel(level);
+    }
+
+    public static void saveEXP(int sequence, int exp) {
+        userMap.get(sequence).setExperiencePoint(exp);
+    }
+
+    public static void saveMoney(int sequence, Money money) {
+        userMap.get(sequence).setMoney(money);
     }
 }

--- a/src/main/java/com/ohgiraffers/webrpg/user/application/dto/UserInfoDTO.java
+++ b/src/main/java/com/ohgiraffers/webrpg/user/application/dto/UserInfoDTO.java
@@ -2,15 +2,13 @@ package com.ohgiraffers.webrpg.user.application.dto;
 
 
 import com.ohgiraffers.webrpg.user.domain.aggregate.enumtype.ElementalType;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@ToString
 public class UserInfoDTO {
 
     private String name;

--- a/src/main/java/com/ohgiraffers/webrpg/user/application/dto/UserLevelUpDTO.java
+++ b/src/main/java/com/ohgiraffers/webrpg/user/application/dto/UserLevelUpDTO.java
@@ -7,8 +7,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString
-public class UserUpgradeStatDTO {
-    private int upgradeLevel;
-    private int totalHP;
-    private int totalSTR;
+public class UserLevelUpDTO {
+    private int balanceEXP;
+    private int newLevel;
 }

--- a/src/main/java/com/ohgiraffers/webrpg/user/application/dto/UserStatDTO.java
+++ b/src/main/java/com/ohgiraffers/webrpg/user/application/dto/UserStatDTO.java
@@ -7,8 +7,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString
-public class UserUpgradeStatDTO {
-    private int upgradeLevel;
+public class UserStatDTO {
     private int totalHP;
     private int totalSTR;
 }

--- a/src/main/java/com/ohgiraffers/webrpg/user/domain/aggregate/entity/User.java
+++ b/src/main/java/com/ohgiraffers/webrpg/user/domain/aggregate/entity/User.java
@@ -16,13 +16,15 @@ public class User {
     private int experiencePoint;
     private ElementalType elementalType;
 
-    public User(int sequence, String name, int defaultHP, int defaultSTR, Money money, int upgradeLevel, ElementalType elementalType) {
+    public User(int sequence, String name, int defaultHP, int defaultSTR, Money money,int level, int  experiencePoint, int upgradeLevel, ElementalType elementalType) {
         this.sequence = sequence;
         this.name = name;
         this.defaultHP = defaultHP;
         this.defaultSTR = defaultSTR;
         this.money = money;
         this.upgradeLevel = upgradeLevel;
+        this.level = level;
+        this.experiencePoint = experiencePoint;
         this.elementalType = elementalType;
     }
 
@@ -93,13 +95,15 @@ public class User {
     @Override
     public String toString() {
         return "User {" +
-                "sequence =" + sequence +
-                "name = " + name +
-                "defaultHP =" + defaultHP +
-                "defaultSTR =" + defaultSTR +
-                "money ="  + money+
-                "upgradeLevel =" + upgradeLevel +
-                "elementalType =" + elementalType +
+                "sequence =" + sequence + " " +
+                "name = " + name + " " +
+                "defaultHP =" + defaultHP + " " +
+                "defaultSTR =" + defaultSTR + " " +
+                "money ="  + money.getValue()+ " " +
+                "Level =" + level + " " +
+                "experiencePoint =" + experiencePoint + " " +
+                "upgradeLevel =" + upgradeLevel + " " +
+                "elementalType =" + elementalType + " " +
                 '}';
     }
 }

--- a/src/main/java/com/ohgiraffers/webrpg/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/ohgiraffers/webrpg/user/domain/repository/UserRepository.java
@@ -1,7 +1,13 @@
 package com.ohgiraffers.webrpg.user.domain.repository;
 
+import com.ohgiraffers.webrpg.user.application.dto.UserLevelUpDTO;
+import com.ohgiraffers.webrpg.user.domain.aggregate.vo.Money;
+
 public interface UserRepository<T> {
     T findUserBySequence(Integer sequence);
 
     T findUserByName(String name);
+    void saveLevelUp(Integer sequence, UserLevelUpDTO userLevelUpDTO);
+
+    void saveMoney(Integer sequence, Money money);
 }

--- a/src/main/java/com/ohgiraffers/webrpg/user/domain/service/UserDomainService.java
+++ b/src/main/java/com/ohgiraffers/webrpg/user/domain/service/UserDomainService.java
@@ -1,22 +1,27 @@
 package com.ohgiraffers.webrpg.user.domain.service;
 
+import com.ohgiraffers.webrpg.user.application.dto.UserLevelUpDTO;
+import com.ohgiraffers.webrpg.user.domain.aggregate.vo.Money;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
 public class UserDomainService {
 
-    @Value("${strikingPowerConstantNumber:10}")
+    @Value("${strikingPowerConstantNumber:1}")
     private int strikingPowerConstantNumber;
 
-    @Value("${HPConstantNumber:10}")
+    @Value("${HPConstantNumber:1}")
     private int HPConstantNumber;
+
+    @Value("${LevelUpConstantNumber:1}")
+    private int LevelUpConstantNumber;
 
     /**
     # 사용자의 총 공격력 계산 메소드
-     기본 공격력 = 사용자의 defaultSTR + level * strikingPowerConstantNumber;
+     기본 공격력 = 사용자의 defaultSTR + level * strikingPowerConstantNumber; 100 + 1*100 = 200 (level = 1, strikingPowerConstantNumber = 100)
      (strikingPowerConstantNumber 는 사전에 정의한 상수)
-     총 공격력 : 기본 공격력 * upgradeLevel 의 제곱
+     총 공격력 : 기본 공격력 * upgradeLevel 의 제곱 200 * 4 = 800 (upgradeLevel = 2)
      만약 upgradeLevel 이 0일 경우, 기본 공격력이 총 공격력
      */
     public int calcTotalStrikingPower(int defaultSTR ,int level, int upgradeLevel) {
@@ -26,13 +31,39 @@ public class UserDomainService {
 
     /**
      # 사용자의 총 체력 계산 메소드
-     기본 체력 = 사용자의 defaultSTR + level * HPConstantNumber;
+     기본 체력 = 사용자의 defaultSTR + level * HPConstantNumber; 1000 + 1*100 = 1100
      (HPConstantNumber 는 사전에 정의한 상수)
-     총 체력 : 기본 체력 * upgradeLevel 의 체력
+     총 체력 : 기본 체력 * upgradeLevel 의 체력 1100 * 4 = 4400
      만약 upgradeLevel 이 0일 경우, 기본 체력이 총 체력
      */
     public int calcTotalHP(int defaultHP ,int level, int upgradeLevel) {
         int basicHP = defaultHP + level * HPConstantNumber;
         return upgradeLevel == 0 ? basicHP : basicHP * (int) Math.pow(upgradeLevel,2);
+    }
+
+    public int calcLevelUpEXP(int userLevel) {
+        return userLevel * 10 * LevelUpConstantNumber;
+    }
+
+    public int calcPossessionEXP(int beforeEXP, int gainEXP) {
+        return beforeEXP + gainEXP;
+    }
+
+    public UserLevelUpDTO calLevelUp(int userLevel, int userPossessionEXP) {
+        int balanceEXP;
+        int newLevel;
+        int levelUpEXP = calcLevelUpEXP(userLevel);
+        if (userPossessionEXP > levelUpEXP) {
+            balanceEXP = userPossessionEXP - levelUpEXP;
+            newLevel = userLevel + 1;
+        } else {
+            balanceEXP = userPossessionEXP;
+            newLevel = userLevel;
+        }
+        return new UserLevelUpDTO(balanceEXP, newLevel);
+    }
+
+    public Money calcBalanceMoney(Money userMoney, int gainMoney){
+        return new Money(userMoney.getValue() + gainMoney);
     }
 }

--- a/src/main/java/com/ohgiraffers/webrpg/user/infra/repository/InMemoryUserRepository.java
+++ b/src/main/java/com/ohgiraffers/webrpg/user/infra/repository/InMemoryUserRepository.java
@@ -1,6 +1,8 @@
 package com.ohgiraffers.webrpg.user.infra.repository;
 
 import com.ohgiraffers.webrpg.database.UserInMemoryDatabase;
+import com.ohgiraffers.webrpg.user.application.dto.UserLevelUpDTO;
+import com.ohgiraffers.webrpg.user.domain.aggregate.vo.Money;
 import com.ohgiraffers.webrpg.user.domain.repository.UserRepository;
 import org.springframework.stereotype.Repository;
 
@@ -15,5 +17,16 @@ public class InMemoryUserRepository<T> implements UserRepository<T> {
     @Override
     public T findUserByName(String name) {
         return UserInMemoryDatabase.findUserByName(name);
+    }
+
+    @Override
+    public void saveLevelUp(Integer sequence, UserLevelUpDTO userLevelUpDTO) {
+        UserInMemoryDatabase.saveLevel(sequence, userLevelUpDTO.getNewLevel());
+        UserInMemoryDatabase.saveEXP(sequence, userLevelUpDTO.getBalanceEXP());
+    }
+
+    @Override
+    public void saveMoney(Integer sequence, Money money) {
+        UserInMemoryDatabase.saveMoney(sequence, money);
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,3 @@
-strikingPowerConstantNumber = 10
-HPConstantNumber = 10
+strikingPowerConstantNumber = 100
+HPConstantNumber = 100
+LevelUpConstantNumber = 5

--- a/src/test/java/com/ohgiraffers/webrpg/WebrpgApplicationTests.java
+++ b/src/test/java/com/ohgiraffers/webrpg/WebrpgApplicationTests.java
@@ -3,7 +3,7 @@ package com.ohgiraffers.webrpg;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+@SpringBootTest(classes = {WebrpgApplicationTests.class})
 class WebrpgApplicationTests {
 
     @Test

--- a/src/test/java/com/ohgiraffers/webrpg/user/application/service/UserApplicationServiceTests.java
+++ b/src/test/java/com/ohgiraffers/webrpg/user/application/service/UserApplicationServiceTests.java
@@ -1,7 +1,78 @@
 package com.ohgiraffers.webrpg.user.application.service;
 
+import com.ohgiraffers.webrpg.configuration.Application;
+import com.ohgiraffers.webrpg.user.application.dto.UserInfoDTO;
+import com.ohgiraffers.webrpg.user.application.dto.UserUpgradeStatDTO;
+import com.ohgiraffers.webrpg.user.domain.aggregate.entity.User;
+import com.ohgiraffers.webrpg.user.domain.aggregate.enumtype.ElementalType;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@SpringBootTest(classes = Application.class)
 public class UserApplicationServiceTests {
+
+    @Autowired
+    private UserApplicationService userApplicationService;
+
+    @Test
+    public void testApplicationService(){
+        assertNotNull(userApplicationService);
+
+    }
+
+    @Test
+    public void testGetInfo() {
+        int sequence = 1;
+        User user = userApplicationService.getUserBySequence(sequence);
+        UserInfoDTO userInfoDTO = userApplicationService.getInfo(user);
+        assertEquals(userInfoDTO.getUserLevel(), 1);
+        assertEquals(userInfoDTO.getUpgradeLevel(), 1);
+        assertEquals(userInfoDTO.getElementalType(), ElementalType.FIRE);
+        assertEquals(userInfoDTO.getTotalHP(), 1100);
+        assertEquals(userInfoDTO.getTotalSTR(), 200);
+    }
+
+    @Test
+    public void testSaveEXPReward(){
+        int sequence = 1;
+        int exp = 100;
+        userApplicationService.saveEXPReward(sequence, exp);
+        User user = userApplicationService.getUserBySequence(sequence);
+        assertEquals(user.getLevel(), 2);
+        assertEquals(user.getExperiencePoint(), 50);
+
+    }
+
+    @Test
+    public void testSaveMoneyReward() {
+        int sequence = 1;
+        int money = 100;
+        userApplicationService.saveMoneyReward(sequence, money);
+        User user = userApplicationService.getUserBySequence(sequence);
+        assertEquals(user.getMoney().getValue(), 100);
+
+    }
+    @Test
+    public void testGetUpgradeStatByFlagSuccess() {
+        int sequence = 1;
+        User user = userApplicationService.getUserBySequence(sequence);
+        UserUpgradeStatDTO userUpgradeStatDTO = userApplicationService.getUpgradeStatByFlag(user, "success");
+        assertEquals(userUpgradeStatDTO.getUpgradeLevel(), 2);
+        assertEquals(userUpgradeStatDTO.getTotalHP(), 4400);
+        assertEquals(userUpgradeStatDTO.getTotalSTR(), 800);
+    }
+
+    @Test
+    public void testGetUpgradeStatByFlagFail() {
+        int sequence = 1;
+        User user = userApplicationService.getUserBySequence(sequence);
+        UserUpgradeStatDTO userUpgradeStatDTO = userApplicationService.getUpgradeStatByFlag(user, "fail");
+        assertEquals(userUpgradeStatDTO.getUpgradeLevel(), 0);
+        assertEquals(userUpgradeStatDTO.getTotalHP(), 1100);
+        assertEquals(userUpgradeStatDTO.getTotalSTR(), 200);
+    }
 }


### PR DESCRIPTION
# 무슨 이유로 코드를 변경했는지

---
* #15 
* #21 
* #24 
---
# 어떤 위험이나 장애가 발견되었는지

---
* 없음
---

# 어떤 부분에 리뷰어가 집중하면 좋을지

---
* 사용자 레벨업 구현
    * 레벨업에 따른 스텟 변경 로직 : #23 
* 사냥 도메인에서 사용하기 위한 사용자 스텟 상세보기 메소드 구현
* 사냥 도메인에서 사용하기 위한 사용자 경험치, 돈 보상 저장 메소드 완료
---

# 관련 스크린샷

---
* 없음
---

# 테스트 계획 또는 완료 사항
![CleanShot 2023-06-23 at 13 43 30](https://github.com/MetaAir2023/WebRPG/assets/19159759/ab7a3c1d-3a0d-4ff6-86af-8a844f89bacb)

* 사용자 레벨 업 테스트 완료
* 사용자 상세보기 테스트 완료
* 사용자 스텟 상세보기 테스트 완료
* 사용자 경험치, 돈 보상 테스트 완료
* 강화 결과에 따른 스텟 변경 테스트 완료
