### PR TITLE
[#59] Upgrade Infra Service DataType Builder 패턴 적용

### DIFF
--- a/src/main/java/com/ohgiraffers/webrpg/upgrade/domain/service/getResult/GetUserInfoResult.java
+++ b/src/main/java/com/ohgiraffers/webrpg/upgrade/domain/service/getResult/GetUserInfoResult.java
@@ -2,15 +2,14 @@ package com.ohgiraffers.webrpg.upgrade.domain.service.getResult;
 
 import com.ohgiraffers.webrpg.user.domain.aggregate.enumtype.ElementalType;
 import com.ohgiraffers.webrpg.user.domain.aggregate.vo.Money;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
+//@Getter
+//@NoArgsConstructor
+//@AllArgsConstructor
+//@ToString
+@Builder
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
-@ToString
 public class GetUserInfoResult {
 
     private String name;

--- a/src/main/java/com/ohgiraffers/webrpg/upgrade/domain/service/getResult/GetUserUpgradeStatResult.java
+++ b/src/main/java/com/ohgiraffers/webrpg/upgrade/domain/service/getResult/GetUserUpgradeStatResult.java
@@ -1,14 +1,9 @@
 package com.ohgiraffers.webrpg.upgrade.domain.service.getResult;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
+@Builder
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
-@ToString
 public class GetUserUpgradeStatResult {
     private int upgradeLevel;
     private int totalHP;

--- a/src/main/java/com/ohgiraffers/webrpg/upgrade/domain/service/getResult/GetUserUpgradeStatusResult.java
+++ b/src/main/java/com/ohgiraffers/webrpg/upgrade/domain/service/getResult/GetUserUpgradeStatusResult.java
@@ -1,14 +1,9 @@
 package com.ohgiraffers.webrpg.upgrade.domain.service.getResult;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
+@Builder
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
-@ToString
 public class GetUserUpgradeStatusResult {
     private int sequence;
     private int userLevel;

--- a/src/main/java/com/ohgiraffers/webrpg/upgrade/infra/service/UserRequestService.java
+++ b/src/main/java/com/ohgiraffers/webrpg/upgrade/infra/service/UserRequestService.java
@@ -27,37 +27,39 @@ public class UserRequestService implements RequestService {
     public GetUserUpgradeStatResult getUserUpgradeStats(int sequence, FlagEnum flag) {
         User user = userApplicationService.getUserBySequence(sequence);
         UserUpgradeStatDTO userUpgradeStatDTO = userApplicationService.getUpgradeStatByFlag(user,flag);
-        return new GetUserUpgradeStatResult(
-                userUpgradeStatDTO.getUpgradeLevel(),
-                userUpgradeStatDTO.getTotalHP(),
-                userUpgradeStatDTO.getTotalSTR()
-        );
+        return GetUserUpgradeStatResult.builder()
+                .upgradeLevel(userUpgradeStatDTO.getUpgradeLevel())
+                .totalHP(userUpgradeStatDTO.getTotalHP())
+                .totalSTR(userUpgradeStatDTO.getTotalSTR())
+                .build();
     }
 
     @Override
     public GetUserInfoResult getUserInfo(int sequence) {
         User user = userApplicationService.getUserBySequence(sequence);
         UserInfoDTO userInfoDTO = userApplicationService.getInfo(user);
-        return new GetUserInfoResult(
-                userInfoDTO.getName(),
-                userInfoDTO.getTotalHP(),
-                userInfoDTO.getTotalSTR(),
-                userInfoDTO.getMoney(),
-                userInfoDTO.getUserLevel(),
-                userInfoDTO.getUpgradeLevel(),
-                userInfoDTO.getElementalType()
-        );
+
+        return GetUserInfoResult.builder()
+                .name(userInfoDTO.getName())
+                .userLevel(userInfoDTO.getUserLevel())
+                .upgradeLevel(userInfoDTO.getUpgradeLevel())
+                .totalHP(userInfoDTO.getTotalHP())
+                .totalSTR(userInfoDTO.getTotalSTR())
+                .elementalType(userInfoDTO.getElementalType())
+                .Money(userInfoDTO.getMoney())
+                .build();
     }
 
     @Override
     public GetUserUpgradeStatusResult getUserUpgradeStatus(int sequence) {
         User user = userApplicationService.getUserBySequence(sequence);
-        return new GetUserUpgradeStatusResult(
-                user.getSequence(),
-                user.getLevel(),
-                user.getUpgradeLevel(),
-                user.getMoney().getValue()
-        );
+
+        return GetUserUpgradeStatusResult.builder()
+                .sequence(user.getSequence())
+                .userLevel(user.getLevel())
+                .upgradeLevel(user.getUpgradeLevel())
+                .money(user.getMoney().getValue())
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ohgiraffers/webrpg/user/application/controller/UserController.java
+++ b/src/main/java/com/ohgiraffers/webrpg/user/application/controller/UserController.java
@@ -52,5 +52,4 @@ public class UserController {
         return  "hunt/huntSelectMap";
     }
 
-
 }

--- a/src/test/java/com/ohgiraffers/webrpg/upgrade/application/controller/UpgradeApplicationServiceTests.java
+++ b/src/test/java/com/ohgiraffers/webrpg/upgrade/application/controller/UpgradeApplicationServiceTests.java
@@ -1,0 +1,82 @@
+package com.ohgiraffers.webrpg.upgrade.application.controller;
+
+import com.ohgiraffers.webrpg.configuration.Application;
+import com.ohgiraffers.webrpg.upgrade.application.dto.UpgradeResultDTO;
+import com.ohgiraffers.webrpg.upgrade.application.service.UpgradeApplicationService;
+import com.ohgiraffers.webrpg.upgrade.domain.aggregate.enumtype.FlagEnum;
+import com.ohgiraffers.webrpg.upgrade.domain.service.RequestService;
+import com.ohgiraffers.webrpg.upgrade.domain.service.getResult.GetUserInfoResult;
+import com.ohgiraffers.webrpg.upgrade.domain.service.getResult.GetUserUpgradeStatResult;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@SpringBootTest(classes = Application.class)
+public class UpgradeApplicationServiceTests {
+
+    private final UpgradeApplicationService upgradeApplicationService;
+    private final RequestService requestService;
+
+    @Autowired
+    public UpgradeApplicationServiceTests(UpgradeApplicationService upgradeApplicationService,
+                                          RequestService requestService) {
+        this.upgradeApplicationService = upgradeApplicationService;
+        this.requestService = requestService;
+    }
+
+    @Test
+    public void testApplicationService(){
+        assertNotNull(upgradeApplicationService);
+    }
+
+    @Test
+    public void testGetUserStatsByFlagIsSuccess() {
+        int userSequence = 1;
+        GetUserUpgradeStatResult result = requestService.getUserUpgradeStats(userSequence,FlagEnum.SUCCESS);
+        assertEquals(result.getUpgradeLevel(),2);
+    }
+
+    @Test
+    public void testGetUserStatsByFlagIsFail() {
+        int userSequence = 1;
+        GetUserUpgradeStatResult result = requestService.getUserUpgradeStats(userSequence,FlagEnum.FAIL);
+        assertEquals(result.getUpgradeLevel(),0);
+    }
+
+    @Test
+    public void testGetUserStatsByFlagIsCurrent() {
+        int userSequence = 1;
+        GetUserUpgradeStatResult result = requestService.getUserUpgradeStats(userSequence,FlagEnum.CURRENT);
+        assertEquals(result.getUpgradeLevel(),1);
+    }
+
+    @Test
+    public void testCheckUpgradeMoney() {
+        int money = 1000;
+        int userLevel = 1;
+        boolean result = upgradeApplicationService.checkUpgradeMoney(money, userLevel);
+        assertEquals(result, true);
+    }
+
+    @Test
+    public void testStart() {
+        int upgradeLevel = 1;
+        int money = 1000;
+        int userLevel = 1;
+        UpgradeResultDTO resultDTO = upgradeApplicationService.start(upgradeLevel, money, userLevel);
+        assertEquals(2, resultDTO.getResultUpgradeLevel());
+        assertEquals(990, resultDTO.getBalance());
+    }
+
+    @Test
+    public void testGetUserInfo() {
+        int userSequence = 1;
+        GetUserInfoResult result = upgradeApplicationService.getUserInfo(userSequence);
+        assertEquals("소드마스터",result.getName());
+    }
+}


### PR DESCRIPTION
# 무슨 이유로 코드를 변경했는지

---
* #59 
---
# 어떤 위험이나 장애가 발견되었는지

---
* 없음
---

# 어떤 부분에 리뷰어가 집중하면 좋을지

---
* Upgrade Infra Service 에서 응답 데이터의 경우 불변해야 하는 객체이기 때문에 Builder 어노테이션과 Getter 어노테이션을 통해 데이터 관리
---

# 관련 스크린샷
<img width="740" alt="CleanShot 2023-06-26 at 15 09 30@2x" src="https://github.com/MetaAir2023/WebRPG/assets/19159759/608992f4-d559-46ce-84e9-ae9cd9e5609c">

---
* 없읍
---

# 테스트 계획 또는 완료 사항

---
* UpgradeApplicationService 테스트 완료
