### PR TITLE
[#87, #88] 로그인 시 비밀번호 추가

### DIFF
--- a/src/main/java/com/ohgiraffers/webrpg/database/UserInMemoryDatabase.java
+++ b/src/main/java/com/ohgiraffers/webrpg/database/UserInMemoryDatabase.java
@@ -3,6 +3,7 @@ package com.ohgiraffers.webrpg.database;
 import com.ohgiraffers.webrpg.user.domain.aggregate.entity.User;
 import com.ohgiraffers.webrpg.user.domain.aggregate.vo.Money;
 import com.ohgiraffers.webrpg.user.domain.aggregate.enumtype.ElementalType;
+import com.ohgiraffers.webrpg.user.domain.aggregate.vo.Password;
 import com.ohgiraffers.webrpg.user.infra.exception.UserExistException;
 
 import java.util.HashMap;
@@ -13,7 +14,7 @@ public abstract class UserInMemoryDatabase {
     private static final Map<Integer, User> userMap = new HashMap<>();
     static {
         userMap.put(1,new User(1, "소드마스터",
-                1000, 100,
+                new Password("HelloWorld"),1000, 100,
                 new Money(1000), 1,0,1,
                 ElementalType.FIRE));
 

--- a/src/main/java/com/ohgiraffers/webrpg/user/application/controller/UserController.java
+++ b/src/main/java/com/ohgiraffers/webrpg/user/application/controller/UserController.java
@@ -4,6 +4,8 @@ import com.ohgiraffers.webrpg.user.application.dto.UserInfoDTO;
 import com.ohgiraffers.webrpg.user.application.dto.loginDTO;
 import com.ohgiraffers.webrpg.user.application.service.UserApplicationService;
 import com.ohgiraffers.webrpg.user.domain.aggregate.entity.User;
+import com.ohgiraffers.webrpg.user.domain.aggregate.vo.Password;
+import com.ohgiraffers.webrpg.user.domain.exception.PasswordUnCorrectException;
 import com.ohgiraffers.webrpg.user.infra.exception.UserExistException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
@@ -28,6 +30,11 @@ public class UserController {
     public String checkUser(HttpSession session, @ModelAttribute("login") loginDTO login, RedirectAttributes rttr) {
         try {
             User user = userApplicationService.getUserByName(login.getUserName());
+
+            Password password = new Password(login.getPassword());
+            if (!password.getValue().equals(user.getPassword().getValue())) {
+                throw new PasswordUnCorrectException("비밀번호가 올바르지 않습니다 !!");
+            }
             UserInfoDTO userInfo = userApplicationService.getInfo(user);
             session.setAttribute("userSequence", userInfo.getSequence());
             session.setAttribute("userName", userInfo.getName());
@@ -35,6 +42,8 @@ public class UserController {
         } catch (Exception e) {
             if(e.getClass() == UserExistException.class) {
                 rttr.addFlashAttribute("exception", "사용자가 존재하지 않습니다 !!");
+            } else if (e.getClass() == PasswordUnCorrectException.class) {
+                rttr.addFlashAttribute("exception", "비밀번호가 올바르지 않습니다 !!");
             }
             return "redirect:/login";
         }

--- a/src/main/java/com/ohgiraffers/webrpg/user/application/dto/loginDTO.java
+++ b/src/main/java/com/ohgiraffers/webrpg/user/application/dto/loginDTO.java
@@ -9,4 +9,5 @@ import lombok.*;
 @ToString
 public class loginDTO {
     private String userName;
+    private String password;
 }

--- a/src/main/java/com/ohgiraffers/webrpg/user/domain/aggregate/entity/User.java
+++ b/src/main/java/com/ohgiraffers/webrpg/user/domain/aggregate/entity/User.java
@@ -2,12 +2,13 @@ package com.ohgiraffers.webrpg.user.domain.aggregate.entity;
 
 import com.ohgiraffers.webrpg.user.domain.aggregate.enumtype.ElementalType;
 import com.ohgiraffers.webrpg.user.domain.aggregate.vo.Money;
+import com.ohgiraffers.webrpg.user.domain.aggregate.vo.Password;
 
 public class User {
 
-    // TODO VO를 통한 level값에 따른 유저 HP, STR, defensivePower 값 처리 [#20]
     private final int sequence;
     private final String name;
+    private final Password password;
     private int defaultHP;
     private int defaultSTR;
     private Money money;
@@ -16,9 +17,10 @@ public class User {
     private int experiencePoint;
     private ElementalType elementalType;
 
-    public User(int sequence, String name, int defaultHP, int defaultSTR, Money money,int level, int  experiencePoint, int upgradeLevel, ElementalType elementalType) {
+    public User(int sequence, String name, Password password, int defaultHP, int defaultSTR, Money money,int level, int  experiencePoint, int upgradeLevel, ElementalType elementalType) {
         this.sequence = sequence;
         this.name = name;
+        this.password = password;
         this.defaultHP = defaultHP;
         this.defaultSTR = defaultSTR;
         this.money = money;
@@ -42,6 +44,10 @@ public class User {
 
     public String getName() {
         return name;
+    }
+
+    public Password getPassword() {
+        return password;
     }
 
     public int getUpgradeLevel() {
@@ -97,6 +103,7 @@ public class User {
         return "User {" +
                 "sequence =" + sequence + " " +
                 "name = " + name + " " +
+                "password = " + password + " "+
                 "defaultHP =" + defaultHP + " " +
                 "defaultSTR =" + defaultSTR + " " +
                 "money ="  + money.getValue()+ " " +

--- a/src/main/java/com/ohgiraffers/webrpg/user/domain/aggregate/vo/Password.java
+++ b/src/main/java/com/ohgiraffers/webrpg/user/domain/aggregate/vo/Password.java
@@ -1,0 +1,35 @@
+package com.ohgiraffers.webrpg.user.domain.aggregate.vo;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+
+public class Password {
+    private String value;
+
+
+    public Password() {
+
+    }
+
+    public Password(String value) {
+
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            md.update((value).getBytes());
+            byte[] pwdSalt = md.digest();
+
+            StringBuffer pwdSb = new StringBuffer();
+            for(byte b : pwdSalt) {
+                pwdSb.append(String.format("%02x", b));
+            }
+            this.value = pwdSb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public String getValue() {
+        return this.value;
+    }
+}

--- a/src/main/java/com/ohgiraffers/webrpg/user/domain/exception/PasswordUnCorrectException.java
+++ b/src/main/java/com/ohgiraffers/webrpg/user/domain/exception/PasswordUnCorrectException.java
@@ -1,0 +1,11 @@
+package com.ohgiraffers.webrpg.user.domain.exception;
+
+public class PasswordUnCorrectException extends RuntimeException {
+    public PasswordUnCorrectException() {
+        super();
+    }
+
+    public PasswordUnCorrectException(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/resources/templates/main/loginPage.html
+++ b/src/main/resources/templates/main/loginPage.html
@@ -38,6 +38,7 @@
 
         <form action="/user/login" method="post" class="formlogin">
             <input type="text" name="userName" placeholder="사용자의 닉네임을 입력해 주세요..." class="inputbox">
+            <input type="password" name="password" placeholder="사용자의 비밀번호를 입력해 주세요..." class="inputbox">
             <input type="submit" value="접속하기" class="loginBtn" style="cursor: url(/img/pointer_cur.png), auto">
 
         </form>


### PR DESCRIPTION
# 무슨 이유로 코드를 변경했는지

---
* #87 
* #88 
---
# 어떤 위험이나 장애가 발견되었는지

---
* 로그인 시 닉네임 뿐만 아니라 비밀번호도 같이 입력하도록 수정
---

# 어떤 부분에 리뷰어가 집중하면 좋을지

---
* User Entity에 Password VO 생성
* Password VO의 생성자로 String을 받으며 **단방향 암호화를 진행**하고 암호화된 문자열을 Password VO의 value로 저장
* 로그인 시 사용자가 입력한 비밀번호를 Password VO로 새로운 객체를 생성
* 2와 3의 getValue를 비교하여 사용자가 입력한 비밀번호와 데이터베이스에 저장된 값이 같은지 비교 (**복호화 과정 없음**)
* 서로 값이 다를 경우 `PasswordUnCorrectException` 발생
---

<img width="1208" alt="CleanShot 2023-06-28 at 10 06 57@2x" src="https://github.com/MetaAir2023/WebRPG/assets/19159759/56cf8cc9-9e3d-4e1b-8c63-c74245692ae9">

![CleanShot 2023-06-28 at 10 13 55](https://github.com/MetaAir2023/WebRPG/assets/19159759/c02809f5-5cba-4b50-95d7-0e2cc5f97fce)

![CleanShot 2023-06-28 at 10 09 08](https://github.com/MetaAir2023/WebRPG/assets/19159759/d2332bfb-881a-4490-863a-7871300e50cb)

# 관련 스크린샷

---
* 없음
---

# 테스트 계획 또는 완료 사항

---
* 없음
